### PR TITLE
Upgrade to Eclipse 4.12 (2019-06) and use Java 8 syntax

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -15,7 +15,7 @@
 	<property name="buildnum-file" value="${confdir}/net/ggtools/grand/ui/buildnum.properties"/>
 	<property name="distdir" value="dist"/>
 	<property name="javadocdir" value="tmp/docs/api"/>
-	<property name="java.target" value="1.6"/>
+	<property name="java.target" value="1.8"/>
 	<property name="bundle.name" value="GrandUI.app"/>
 	<property name="bundle.launcher.name" value="JavaAppLauncher"/>
 
@@ -118,19 +118,11 @@
 			<fileset dir="${extlibdir}" excludes="org.eclipse.swt.*.jar,swt.jar,appbundler.jar"/>
 		</copy>
 		<!-- Names of SWT platform-specific libraries are incompatible with JPMS automatic module naming -->
-		<copy todir="tmp/${product.fullname}/lib/gtk/x86">
-			<fileset dir="${extlibdir}" includes="org.eclipse.swt.gtk.*.x86-*.jar"/>
-			<regexpmapper from="([^-]*).x86-(\d+\.\d+\.\d+).*\.jar" to="\1-\2.jar"/>
-		</copy>
-		<copy todir="tmp/${product.fullname}/lib/gtk/x86_64">
+		<copy todir="tmp/${product.fullname}/lib/gtk">
 			<fileset dir="${extlibdir}" includes="org.eclipse.swt.gtk.*.x86_64-*.jar"/>
 			<regexpmapper from="([^-]*).x86_64-(\d+\.\d+\.\d+).*\.jar" to="\1-\2.jar"/>
 		</copy>
-		<copy todir="tmp/${product.fullname}/lib/win32/x86">
-			<fileset dir="${extlibdir}" includes="org.eclipse.swt.win32.*.x86-*.jar"/>
-			<regexpmapper from="([^-]*).x86-(\d+\.\d+\.\d+).*\.jar" to="\1-\2.jar"/>
-		</copy>
-		<copy todir="tmp/${product.fullname}/lib/win32/x86_64">
+		<copy todir="tmp/${product.fullname}/lib/win32">
 			<fileset dir="${extlibdir}" includes="org.eclipse.swt.win32.*.x86_64-*.jar"/>
 			<regexpmapper from="([^-]*).x86_64-(\d+\.\d+\.\d+).*\.jar" to="\1-\2.jar"/>
 		</copy>
@@ -284,7 +276,7 @@
 
 	<target name="set-eclipse-deps" depends="set-swt-properties" if="eclipse.pdebuild.home">
 		<copy tofile="${extlibdir}/swt.jar">
-			<fileset dir="${extlibdir}" includes="org.eclipse.swt.${swtfw}.${swtarch}-*.jar"/>
+			<fileset dir="${extlibdir}" includes="org.eclipse.swt.${swtfw}.x86_64-*.jar"/>
 		</copy>
 	</target>
 
@@ -299,10 +291,6 @@
 
 		<condition property="swtfw" value="cocoa.macosx">
 			<os family="mac"/>
-		</condition>
-
-		<condition property="swtarch" value="x86_64" else="x86">
-			<equals arg1="${sun.arch.data.model}" arg2="64"/>
 		</condition>
 	</target>
 </project>

--- a/ivy.settings.xml
+++ b/ivy.settings.xml
@@ -1,5 +1,5 @@
 <ivysettings>
-  <property name="eclipse.updatesite" value="http://download.eclipse.org/eclipse/updates/4.9/"/>
+  <property name="eclipse.updatesite" value="http://download.eclipse.org/eclipse/updates/4.12/"/>
   <property name="gef.legacy.updatesite" value="http://download.eclipse.org/tools/gef/updates/legacy/releases/"/>
   <property name="central.repo" value="http://repo1.maven.org/maven2" override="false"/>
   <settings defaultResolver="default"/>

--- a/ivy.xml
+++ b/ivy.xml
@@ -17,15 +17,13 @@
     <dependency org="oro" name="oro" rev="2.0.8"/>
     <dependency org="ant-contrib" name="ant-contrib" rev="1.0b3"/>
     <dependency org="commons-logging" name="commons-logging" rev="1.2" conf="compile->default"/>
-    <dependency org="bundle" name="com.ibm.icu" rev="62.+" conf="compile->default"/>
+    <dependency org="bundle" name="com.ibm.icu" rev="64.+" conf="compile->default"/>
     <dependency org="bundle" name="org.eclipse.draw2d" rev="3.+" conf="compile->default"/>
     <dependency org="bundle" name="org.eclipse.core.commands" rev="3.+" conf="compile->default"/>
     <dependency org="bundle" name="org.eclipse.equinox.common" rev="3.+" conf="compile->default"/>
     <dependency org="bundle" name="org.eclipse.jface" rev="3.+" conf="compile->default"/>
     <dependency org="bundle" name="org.eclipse.osgi" rev="3.+" conf="compile->default"/>
-    <dependency org="bundle" name="org.eclipse.swt.win32.win32.x86" rev="3.+" conf="win32->default"/>
     <dependency org="bundle" name="org.eclipse.swt.win32.win32.x86_64" rev="3.+" conf="win32->default"/>
-    <dependency org="bundle" name="org.eclipse.swt.gtk.linux.x86" rev="3.+" conf="linux->default"/>
     <dependency org="bundle" name="org.eclipse.swt.gtk.linux.x86_64" rev="3.+" conf="linux->default"/>
     <dependency org="bundle" name="org.eclipse.swt.cocoa.macosx.x86_64" rev="3.+" conf="macos->default"/>
     <exclude org="bundle" module="org.eclipse.swt"/>

--- a/src/main/java/net/ggtools/grand/ui/RecentFilesManager.java
+++ b/src/main/java/net/ggtools/grand/ui/RecentFilesManager.java
@@ -70,7 +70,7 @@ public final class RecentFilesManager
     /**
      * Field recentFiles.
      */
-    private final LinkedList<String> recentFiles = new LinkedList<String>();
+    private final LinkedList<String> recentFiles = new LinkedList<>();
 
     /**
      * Field preferenceStore.
@@ -91,7 +91,7 @@ public final class RecentFilesManager
      * Private constructor.
      */
     private RecentFilesManager() {
-        subscribers = new HashSet<RecentFilesListener>();
+        subscribers = new HashSet<>();
         readOnlyRecentFiles = Collections.unmodifiableList(recentFiles);
         preferenceStore = Application.getInstance().getPreferenceStore();
         loadRecentFiles();

--- a/src/main/java/net/ggtools/grand/ui/actions/ExportGraphAction.java
+++ b/src/main/java/net/ggtools/grand/ui/actions/ExportGraphAction.java
@@ -89,9 +89,19 @@ public class ExportGraphAction extends GraphControllerAction {
         final ImageSaver imageSaver = new ImageSaver();
         dialog.setFilterExtensions(imageSaver.getSupportedExtensions());
         dialog.setText("Export graph as image");
-        final String fileName = dialog.open();
-        LOG.debug("Dialog returned " + fileName);
+        String fileName = dialog.open();
+        LOG.debug("Dialog returned file name " + fileName);
         if (fileName != null) {
+            int filterIndex = dialog.getFilterIndex();
+            // TODO why does this not work with GTK?
+            if (filterIndex >= 0) {
+                String fileExtension = imageSaver.getSupportedExtensions()[filterIndex]
+                        .replace("*", "");
+                LOG.debug("Dialog returned file extension " + fileExtension);
+                if (!fileName.endsWith(fileExtension)) {
+                    fileName += fileExtension;
+                }
+            }
             Image image = null;
             try {
                 image = getGraphController().createImageForGraph();

--- a/src/main/java/net/ggtools/grand/ui/actions/ExportGraphAction.java
+++ b/src/main/java/net/ggtools/grand/ui/actions/ExportGraphAction.java
@@ -106,10 +106,7 @@ public class ExportGraphAction extends GraphControllerAction {
             try {
                 image = getGraphController().createImageForGraph();
                 imageSaver.saveImage(image, fileName);
-            } catch (final IllegalArgumentException e) {
-                ExceptionDialog.openException(parentShell, "Cannot export image", e);
-
-            } catch (final IOException e) {
+            } catch (final IllegalArgumentException | IOException e) {
                 ExceptionDialog.openException(parentShell, "Cannot export image", e);
             } finally {
                 if (image != null) {

--- a/src/main/java/net/ggtools/grand/ui/actions/FilterSelectedNodesAction.java
+++ b/src/main/java/net/ggtools/grand/ui/actions/FilterSelectedNodesAction.java
@@ -82,7 +82,7 @@ public class FilterSelectedNodesAction extends GraphListenerAction {
             LOG.debug("run() - start");
         }
 
-        final List<String> nodeList = new LinkedList<String>();
+        final List<String> nodeList = new LinkedList<>();
         for (final Draw2dNode node : getGraphController().getSelection()) {
             nodeList.add(node.getName());
         }

--- a/src/main/java/net/ggtools/grand/ui/event/EventManager.java
+++ b/src/main/java/net/ggtools/grand/ui/event/EventManager.java
@@ -156,13 +156,13 @@ public class EventManager implements Runnable {
     /**
      * Field eventQueue.
      */
-    private final LinkedList<Runnable> eventQueue = new LinkedList<Runnable>();
+    private final LinkedList<Runnable> eventQueue = new LinkedList<>();
 
     /**
      * Field listenerList.
      */
     private final List<WeakReference<Object>> listenerList =
-            new LinkedList<WeakReference<Object>>();
+            new LinkedList<>();
 
     /**
      * Field name.
@@ -361,7 +361,7 @@ public class EventManager implements Runnable {
         }
 
         synchronized (listenerList) {
-            listenerList.add(new WeakReference<Object>(listener));
+            listenerList.add(new WeakReference<>(listener));
         }
     }
 

--- a/src/main/java/net/ggtools/grand/ui/graph/DotGraphCreator.java
+++ b/src/main/java/net/ggtools/grand/ui/graph/DotGraphCreator.java
@@ -109,9 +109,9 @@ public class DotGraphCreator
     public DotGraphCreator(final Graph graph, final boolean useBusRouting) {
         this.graph = graph;
         this.useBusRouting = useBusRouting;
-        nameDimensions = new HashMap<String, IVertex>();
+        nameDimensions = new HashMap<>();
         dotGraph = new DotGraph(IGraph.GRAPH, graph.getName());
-        vertexLUT = new HashMap<String, IVertex>();
+        vertexLUT = new HashMap<>();
         startNode = graph.getStartNode();
     }
 

--- a/src/main/java/net/ggtools/grand/ui/graph/DotGraphCreator.java
+++ b/src/main/java/net/ggtools/grand/ui/graph/DotGraphCreator.java
@@ -133,16 +133,14 @@ public class DotGraphCreator
         }
 
         // Update width and height in nodes.
-        Display.getDefault().syncExec(new Runnable() {
-            public void run() {
-                final Font systemFont = Application.getInstance().getFont(Application.NODE_FONT);
-                for (final Entry<String, IVertex> entry : nameDimensions.entrySet()) {
-                    final IVertex vertex = entry.getValue();
+        Display.getDefault().syncExec(() -> {
+            final Font systemFont = Application.getInstance().getFont(Application.NODE_FONT);
+            for (final Entry<String, IVertex> entry : nameDimensions.entrySet()) {
+                final IVertex vertex = entry.getValue();
 
-                    final Dimension dim = FigureUtilities.getTextExtents(entry.getKey(), systemFont);
-                    vertex.setAttr(MINWIDTH_ATTR, Math.max(dim.width, 50));
-                    vertex.setAttr(MINHEIGHT_ATTR, Math.max(dim.height, 25));
-                }
+                final Dimension dim = FigureUtilities.getTextExtents(entry.getKey(), systemFont);
+                vertex.setAttr(MINWIDTH_ATTR, Math.max(dim.width, 50));
+                vertex.setAttr(MINHEIGHT_ATTR, Math.max(dim.height, 25));
             }
         });
 

--- a/src/main/java/net/ggtools/grand/ui/graph/GraphController.java
+++ b/src/main/java/net/ggtools/grand/ui/graph/GraphController.java
@@ -205,10 +205,7 @@ public class GraphController implements DotGraphAttributes, SelectionManager,
                     .getDeclaredMethod("selectionChanged", Collection.class));
             parameterChangedEvent = graphEventManager.createDispatcher(GraphListener.class
                     .getDeclaredMethod("parameterChanged", GraphController.class));
-        } catch (final SecurityException e) {
-            LOG.fatal("Caught exception initializing GraphController", e);
-            throw new RuntimeException("Cannot instantiate GraphController", e);
-        } catch (final NoSuchMethodException e) {
+        } catch (final SecurityException | NoSuchMethodException e) {
             LOG.fatal("Caught exception initializing GraphController", e);
             throw new RuntimeException("Cannot instantiate GraphController", e);
         }
@@ -236,9 +233,7 @@ public class GraphController implements DotGraphAttributes, SelectionManager,
                     renderFilteredGraph(progressMonitor);
                 }
             }, true, progressMonitor, Display.getCurrent());
-        } catch (final InvocationTargetException e) {
-            reportError("Cannot add filter", e);
-        } catch (final InterruptedException e) {
+        } catch (final InvocationTargetException | InterruptedException e) {
             reportError("Cannot add filter", e);
         } finally {
             progressMonitor.done();
@@ -273,9 +268,7 @@ public class GraphController implements DotGraphAttributes, SelectionManager,
                     renderFilteredGraph(progressMonitor);
                 }
             }, true, progressMonitor, Display.getCurrent());
-        } catch (final InvocationTargetException e) {
-            reportError("Cannot clear filters", e);
-        } catch (final InterruptedException e) {
+        } catch (final InvocationTargetException | InterruptedException e) {
             reportError("Cannot clear filters", e);
         } finally {
             progressMonitor.done();
@@ -453,10 +446,7 @@ public class GraphController implements DotGraphAttributes, SelectionManager,
                 LOG.info("Graph loaded & rendered");
             }
             RecentFilesManager.getInstance().addNewFile(file, properties);
-        } catch (final GrandException e) {
-            reportError("Cannot open graph", e);
-            stopController();
-        } catch (final BuildException e) {
+        } catch (final GrandException | BuildException e) {
             reportError("Cannot open graph", e);
             stopController();
         } finally {

--- a/src/main/java/net/ggtools/grand/ui/graph/GraphController.java
+++ b/src/main/java/net/ggtools/grand/ui/graph/GraphController.java
@@ -170,7 +170,7 @@ public class GraphController implements DotGraphAttributes, SelectionManager,
     /**
      * Field selectedNodes.
      */
-    private final Set<Draw2dNode> selectedNodes = new HashSet<Draw2dNode>();
+    private final Set<Draw2dNode> selectedNodes = new HashSet<>();
 
     /**
      * Field selectionChangedDispatcher.

--- a/src/main/java/net/ggtools/grand/ui/graph/GraphNodeContentProvider.java
+++ b/src/main/java/net/ggtools/grand/ui/graph/GraphNodeContentProvider.java
@@ -122,7 +122,7 @@ public class GraphNodeContentProvider implements IStructuredContentProvider,
             return null;
         }
 
-        final List<Node> list = new LinkedList<Node>();
+        final List<Node> list = new LinkedList<>();
         for (final Iterator<Node> iter = graph.getNodes(); iter.hasNext();) {
             list.add(iter.next());
         }

--- a/src/main/java/net/ggtools/grand/ui/graph/draw2d/Draw2dGraph.java
+++ b/src/main/java/net/ggtools/grand/ui/graph/draw2d/Draw2dGraph.java
@@ -227,7 +227,7 @@ public class Draw2dGraph extends Panel implements SelectionManager {
     /**
      * Field nodeIndex.
      */
-    private final Map<String, Draw2dNode> nodeIndex = new HashMap<String, Draw2dNode>();
+    private final Map<String, Draw2dNode> nodeIndex = new HashMap<>();
 
     /**
      * Field scroller.

--- a/src/main/java/net/ggtools/grand/ui/graph/draw2d/Draw2dGraphRenderer.java
+++ b/src/main/java/net/ggtools/grand/ui/graph/draw2d/Draw2dGraphRenderer.java
@@ -158,8 +158,7 @@ public class Draw2dGraphRenderer implements DotGraphAttributes {
     private PolylineConnection addConnectionFromRoute(final IFigure contents,
             final String name, final DotRoute route) {
         final float[] coords = new float[6];
-        final List<AbsoluteBendpoint> bends =
-                new ArrayList<AbsoluteBendpoint>();
+        final List<AbsoluteBendpoint> bends = new ArrayList<>();
         boolean isFirstPoint = true;
         final Point min = new Point(Integer.MAX_VALUE, Integer.MAX_VALUE);
         final Point max = new Point(Integer.MIN_VALUE, Integer.MIN_VALUE);

--- a/src/main/java/net/ggtools/grand/ui/image/ImageSaver.java
+++ b/src/main/java/net/ggtools/grand/ui/image/ImageSaver.java
@@ -241,8 +241,9 @@ public class ImageSaver {
             FORMAT_REGISTRY.put("gif", new ImageFormat("gif", SWT.IMAGE_GIF, true));
             FORMAT_REGISTRY.put("png", new ImageFormat("png", SWT.IMAGE_PNG, false));
             FORMAT_REGISTRY.put("bmp", new ImageFormat("bmp", SWT.IMAGE_BMP, false));
-            supportedExtensions = FORMAT_REGISTRY.keySet().toArray(
-                    new String[FORMAT_REGISTRY.keySet().size()]);
+            supportedExtensions = FORMAT_REGISTRY.keySet().stream()
+                    .map(s -> SWT.getPlatform().equals("cocoa") ? s : "*." + s)
+                    .toArray(String[]::new);
             formatInitDone = true;
         }
     }

--- a/src/main/java/net/ggtools/grand/ui/image/ImageSaver.java
+++ b/src/main/java/net/ggtools/grand/ui/image/ImageSaver.java
@@ -117,8 +117,7 @@ public class ImageSaver {
     /**
      * Field formatRegistry.
      */
-    private static final Map<String, ImageFormat> FORMAT_REGISTRY =
-            new HashMap<String, ImageFormat>();
+    private static final Map<String, ImageFormat> FORMAT_REGISTRY = new HashMap<>();
 
     /**
      * Logger for this class.
@@ -166,7 +165,7 @@ public class ImageSaver {
         }
 
         // compute a histogram of color frequencies
-        final Map<RGB, ColorCounter> freq = new HashMap<RGB, ColorCounter>();
+        final Map<RGB, ColorCounter> freq = new HashMap<>();
         final int width = data.width;
         final int[] pixels = new int[width];
         final int[] maskPixels = new int[width];

--- a/src/main/java/net/ggtools/grand/ui/image/ImageSaver.java
+++ b/src/main/java/net/ggtools/grand/ui/image/ImageSaver.java
@@ -30,7 +30,6 @@ package net.ggtools.grand.ui.image;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -184,9 +183,8 @@ public class ImageSaver {
         }
 
         // sort colors by most frequently used
-        final ColorCounter[] counters = new ColorCounter[freq.size()];
-        freq.values().toArray(counters);
-        Arrays.sort(counters);
+        final ColorCounter[] counters = freq.values().stream().sorted()
+                .toArray(ColorCounter[]::new);
 
         // pick the most frequently used 256 (or fewer), and make a palette
         ImageData mask = null;

--- a/src/main/java/net/ggtools/grand/ui/log/Analyzer.java
+++ b/src/main/java/net/ggtools/grand/ui/log/Analyzer.java
@@ -28,7 +28,6 @@
 package net.ggtools.grand.ui.log;
 
 import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 
@@ -101,13 +100,7 @@ public class Analyzer extends ApplicationWindow {
                         try {
                             ois = new ObjectInputStream(new FileInputStream(logFileName));
                             logViewer.setLogBuffer((LogEventBuffer) ois.readObject());
-                        } catch (final FileNotFoundException e) {
-                            // TODO auto-generated catch block
-                            e.printStackTrace();
-                        } catch (final IOException e) {
-                            // TODO auto-generated catch block
-                            e.printStackTrace();
-                        } catch (final ClassNotFoundException e) {
+                        } catch (final ClassNotFoundException | IOException e) {
                             // TODO auto-generated catch block
                             e.printStackTrace();
                         } finally {

--- a/src/main/java/net/ggtools/grand/ui/log/LogEventBufferImpl.java
+++ b/src/main/java/net/ggtools/grand/ui/log/LogEventBufferImpl.java
@@ -69,7 +69,7 @@ public final class LogEventBufferImpl implements LogEventBuffer {
     /**
      * Field eventList.
      */
-    private final LinkedList<LogEvent> eventList = new LinkedList<LogEvent>();
+    private final LinkedList<LogEvent> eventList = new LinkedList<>();
 
     /**
      * Field listener.

--- a/src/main/java/net/ggtools/grand/ui/log/LogLabelProvider.java
+++ b/src/main/java/net/ggtools/grand/ui/log/LogLabelProvider.java
@@ -57,7 +57,7 @@ class LogLabelProvider implements ITableLabelProvider, ITableColorProvider {
     /**
      * Field logLevelIcons.
      */
-    private final Map<Level, Image> logLevelIcons = new HashMap<Level, Image>();
+    private final Map<Level, Image> logLevelIcons = new HashMap<>();
 
     /**
      *

--- a/src/main/java/net/ggtools/grand/ui/log/LogViewer.java
+++ b/src/main/java/net/ggtools/grand/ui/log/LogViewer.java
@@ -244,11 +244,7 @@ public class LogViewer extends Composite {
                 }
 
                 if (myEvent != null) {
-                    display.syncExec(new Runnable() {
-                        public void run() {
-                            refreshViewer();
-                        }
-                    });
+                    display.syncExec(LogViewer.this::refreshViewer);
                 }
 
                 try {

--- a/src/main/java/net/ggtools/grand/ui/log/LogViewer.java
+++ b/src/main/java/net/ggtools/grand/ui/log/LogViewer.java
@@ -36,16 +36,12 @@ import java.util.Iterator;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.eclipse.jface.viewers.ArrayContentProvider;
-import org.eclipse.jface.viewers.DoubleClickEvent;
-import org.eclipse.jface.viewers.IDoubleClickListener;
 import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.jface.viewers.TableViewer;
 import org.eclipse.jface.viewers.Viewer;
 import org.eclipse.jface.viewers.ViewerFilter;
 import org.eclipse.swt.SWT;
-import org.eclipse.swt.events.DisposeEvent;
-import org.eclipse.swt.events.DisposeListener;
 import org.eclipse.swt.events.SelectionAdapter;
 import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.graphics.GC;
@@ -505,6 +501,7 @@ public class LogViewer extends Composite {
      * Method createViewer.
      * @param parent Composite
      */
+    @SuppressWarnings("unchecked")
     private void createViewer(final Composite parent) {
         viewer = new TableViewer(parent, SWT.READ_ONLY | SWT.H_SCROLL
                 | SWT.V_SCROLL | SWT.HIDE_SELECTION);
@@ -560,29 +557,23 @@ public class LogViewer extends Composite {
         }
         gc.dispose();
 
-        table.addDisposeListener(new DisposeListener() {
-
-            public void widgetDisposed(final DisposeEvent e) {
-                if (LOG.isTraceEnabled()) {
-                    LOG.trace("Table disposed");
-                }
-                stopRefreshThread();
+        table.addDisposeListener(e -> {
+            if (LOG.isTraceEnabled()) {
+                LOG.trace("Table disposed");
             }
+            stopRefreshThread();
         });
 
-        viewer.addDoubleClickListener(new IDoubleClickListener() {
-            @SuppressWarnings("unchecked")
-            public void doubleClick(final DoubleClickEvent event) {
-                final ISelection s = event.getSelection();
-                if (s instanceof IStructuredSelection) {
-                    final IStructuredSelection selection = (IStructuredSelection) s;
-                    for (final Iterator<LogEvent> iter = selection.iterator(); iter.hasNext();) {
-                        final LogEvent logEvent = iter.next();
-                        final LogEventDetailDialog window = new LogEventDetailDialog(getShell(),
-                                logEvent);
-                        window.setBlockOnOpen(false);
-                        window.open();
-                    }
+        viewer.addDoubleClickListener(event -> {
+            final ISelection s = event.getSelection();
+            if (s instanceof IStructuredSelection) {
+                final IStructuredSelection selection = (IStructuredSelection) s;
+                for (final Iterator<LogEvent> iter = selection.iterator(); iter.hasNext();) {
+                    final LogEvent logEvent = iter.next();
+                    final LogEventDetailDialog window = new LogEventDetailDialog(getShell(),
+                            logEvent);
+                    window.setBlockOnOpen(false);
+                    window.open();
                 }
             }
         });

--- a/src/main/java/net/ggtools/grand/ui/menu/RecentFilesMenu.java
+++ b/src/main/java/net/ggtools/grand/ui/menu/RecentFilesMenu.java
@@ -123,23 +123,21 @@ public class RecentFilesMenu extends MenuManager
      * @see net.ggtools.grand.ui.RecentFilesListener#refreshRecentFiles(Collection)
      */
     public final void refreshRecentFiles(final Collection<String> recentFiles) {
-        final Runnable runnable = new Runnable() {
-            public void run() {
-                // Clear the previous items.
-                final IContributionItem[] items = getItems();
+        final Runnable runnable = () -> {
+            // Clear the previous items.
+            final IContributionItem[] items = getItems();
 
-                for (int i = indexOf(RECENT_FILES_GROUP) + 1; i < items.length; i++) {
-                    IContributionItem item = items[i];
-                    if (item.isGroupMarker()) {
-                        break;
-                    }
-                    remove(item);
+            for (int i = indexOf(RECENT_FILES_GROUP) + 1; i < items.length; i++) {
+                IContributionItem item = items[i];
+                if (item.isGroupMarker()) {
+                    break;
                 }
+                remove(item);
+            }
 
-                // Re-add the contents.
-                for (final String fileName : recentFiles) {
-                    appendToGroup(RECENT_FILES_GROUP, new OpenRecentFileAction(window, fileName));
-                }
+            // Re-add the contents.
+            for (final String fileName : recentFiles) {
+                appendToGroup(RECENT_FILES_GROUP, new OpenRecentFileAction(window, fileName));
             }
         };
 

--- a/src/main/java/net/ggtools/grand/ui/prefs/ComplexPreferenceStore.java
+++ b/src/main/java/net/ggtools/grand/ui/prefs/ComplexPreferenceStore.java
@@ -224,8 +224,7 @@ public class ComplexPreferenceStore extends PreferenceStore {
     /**
      * Field propertiesTable.
      */
-    private final Map<String, Properties> propertiesTable =
-            new HashMap<String, Properties>();
+    private final Map<String, Properties> propertiesTable = new HashMap<>();
 
     /**
      * Get a collection of {@link String}s.
@@ -250,7 +249,7 @@ public class ComplexPreferenceStore extends PreferenceStore {
      */
     public final Collection<String> getCollection(final String key,
             final int limit) {
-        final LinkedList<String> list = new LinkedList<String>();
+        final LinkedList<String> list = new LinkedList<>();
         final StringTokenizer tokenizer =
                 new StringTokenizer(getString(key), ",");
         final int lim = (limit == COLLECTION_NO_LIMIT) ? tokenizer.countTokens() : limit;

--- a/src/main/java/net/ggtools/grand/ui/prefs/ComplexPreferenceStore.java
+++ b/src/main/java/net/ggtools/grand/ui/prefs/ComplexPreferenceStore.java
@@ -117,7 +117,7 @@ public class ComplexPreferenceStore extends PreferenceStore {
          * Method getKeys.
          * @return Collection
          */
-        Collection<?> getKeys();
+        Collection<String> getKeys();
 
         /**
          * Method needSaving.
@@ -437,8 +437,8 @@ public class ComplexPreferenceStore extends PreferenceStore {
                         return props.getProperty(key);
                     }
 
-                    public Collection<Object> getKeys() {
-                        return props.keySet();
+                    public Collection<String> getKeys() {
+                        return props.stringPropertyNames();
                     }
 
                     public boolean needSaving(final String key) {
@@ -560,8 +560,7 @@ public class ComplexPreferenceStore extends PreferenceStore {
     private void saveProperties(final Document doc, final Element properties,
             final PropertySaver saver) {
         // TODO solve the properties problem.
-        for (Object i : saver.getKeys()) {
-            final String key = (i instanceof String) ? (String) i : i.toString();
+        for (final String key : saver.getKeys()) {
             if (saver.needSaving(key)) {
                 final Element entry = (Element) properties.appendChild(doc.createElement(ENTRY_ELEMENT));
                 entry.setAttribute(KEY_ATTRIBUTE, key);

--- a/src/main/java/net/ggtools/grand/ui/prefs/ComplexPreferenceStore.java
+++ b/src/main/java/net/ggtools/grand/ui/prefs/ComplexPreferenceStore.java
@@ -323,10 +323,7 @@ public class ComplexPreferenceStore extends PreferenceStore {
                 final DocumentBuilder db = dbf.newDocumentBuilder();
 //                final InputSource inputSource = new InputSource(is);
                 doc = db.parse(is);
-            } catch (final ParserConfigurationException e) {
-                LOG.error("Got exception while parsing preference file", e);
-                throw new Error(e);
-            } catch (final SAXException e) {
+            } catch (final ParserConfigurationException | SAXException e) {
                 LOG.error("Got exception while parsing preference file", e);
                 throw new Error(e);
             }

--- a/src/main/java/net/ggtools/grand/ui/prefs/ComplexPreferenceStore.java
+++ b/src/main/java/net/ggtools/grand/ui/prefs/ComplexPreferenceStore.java
@@ -311,9 +311,7 @@ public class ComplexPreferenceStore extends PreferenceStore {
      */
     @Override
     public void load() throws IOException {
-        FileInputStream is = null;
-        try {
-            is = new FileInputStream(prefFile);
+        try (FileInputStream is = new FileInputStream(prefFile)) {
             final DocumentBuilderFactory dbf =
                     DocumentBuilderFactory.newInstance();
             dbf.setIgnoringElementContentWhitespace(true);
@@ -376,10 +374,6 @@ public class ComplexPreferenceStore extends PreferenceStore {
             };
 
             loadProperties(rootElement, loader);
-        } finally {
-            if (is != null) {
-                is.close();
-            }
         }
     }
 
@@ -390,9 +384,7 @@ public class ComplexPreferenceStore extends PreferenceStore {
      */
     @Override
     public void save() throws IOException {
-        FileOutputStream os = null;
-        try {
-            os = new FileOutputStream(prefFile);
+        try (FileOutputStream os = new FileOutputStream(prefFile)) {
             final DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
             DocumentBuilder db = null;
             try {
@@ -465,10 +457,6 @@ public class ComplexPreferenceStore extends PreferenceStore {
             } catch (final TransformerException e) {
                 LOG.error("Cannot save preferences", e);
                 throw new IOException("Cannot save preferences", e);
-            }
-        } finally {
-            if (os != null) {
-                os.close();
             }
         }
     }

--- a/src/main/java/net/ggtools/grand/ui/prefs/NodesPreferencePage.java
+++ b/src/main/java/net/ggtools/grand/ui/prefs/NodesPreferencePage.java
@@ -103,7 +103,7 @@ public class NodesPreferencePage extends PreferencePage
     /**
      * Field fields.
      */
-    private final List<FieldEditor> fields = new ArrayList<FieldEditor>();
+    private final List<FieldEditor> fields = new ArrayList<>();
 
     /**
      * Creates a new NodesPreferencePage instance using the default
@@ -161,7 +161,7 @@ public class NodesPreferencePage extends PreferencePage
         final Composite parent = new Composite(tabFolder, SWT.NONE);
         tabItem.setControl(parent);
 
-        final List<FieldEditor> tabFields = new LinkedList<FieldEditor>();
+        final List<FieldEditor> tabFields = new LinkedList<>();
         final ColorFieldEditor fgcolorField = new ColorFieldEditor(prefix
                 + "fgcolor", "Foreground", parent);
         tabFields.add(fgcolorField);

--- a/src/main/java/net/ggtools/grand/ui/prefs/SpinnerFieldEditor.java
+++ b/src/main/java/net/ggtools/grand/ui/prefs/SpinnerFieldEditor.java
@@ -4,8 +4,6 @@ import org.eclipse.core.runtime.Assert;
 import org.eclipse.jface.preference.FieldEditor;
 import org.eclipse.jface.resource.JFaceResources;
 import org.eclipse.swt.SWT;
-import org.eclipse.swt.events.DisposeEvent;
-import org.eclipse.swt.events.DisposeListener;
 import org.eclipse.swt.events.FocusAdapter;
 import org.eclipse.swt.events.FocusEvent;
 import org.eclipse.swt.events.KeyAdapter;
@@ -319,11 +317,7 @@ public class SpinnerFieldEditor extends FieldEditor {
             default:
                 Assert.isTrue(false, "Unknown validate strategy"); //$NON-NLS-1$
             }
-            spinner.addDisposeListener(new DisposeListener() {
-                public void widgetDisposed(final DisposeEvent event) {
-                    spinner = null;
-                }
-            });
+            spinner.addDisposeListener(event -> spinner = null);
             if (textLimit > 0) { // Only set limits above 0 - see SWT spec
                 spinner.setTextLimit(textLimit);
             }

--- a/src/main/java/net/ggtools/grand/ui/widgets/ExceptionDialog.java
+++ b/src/main/java/net/ggtools/grand/ui/widgets/ExceptionDialog.java
@@ -76,10 +76,6 @@ public final class ExceptionDialog extends ErrorDialog {
         } else {
             display = parent.getDisplay();
         }
-        display.syncExec(new Runnable() {
-            public void run() {
-                ErrorDialog.openError(parent, message, e.getMessage(), topStatus);
-            }
-        });
+        display.syncExec(() -> ErrorDialog.openError(parent, message, e.getMessage(), topStatus));
     }
 }

--- a/src/main/java/net/ggtools/grand/ui/widgets/FileSelectionPage.java
+++ b/src/main/java/net/ggtools/grand/ui/widgets/FileSelectionPage.java
@@ -84,7 +84,7 @@ public class FileSelectionPage extends WizardPage
     public FileSelectionPage() {
         super("fileselect", "Build file selection", null);
         setDescription("Select the build file to be opened");
-        subscribers = new HashSet<SelectedFileListener>();
+        subscribers = new HashSet<>();
     }
 
     /**

--- a/src/main/java/net/ggtools/grand/ui/widgets/GraphTabItem.java
+++ b/src/main/java/net/ggtools/grand/ui/widgets/GraphTabItem.java
@@ -492,7 +492,7 @@ public class GraphTabItem extends CTabItem
      */
     public final void selectionChanged(final Collection<Draw2dNode> selectedNodes) {
 
-        final List<Node> selection = new ArrayList<Node>(selectedNodes.size());
+        final List<Node> selection = new ArrayList<>(selectedNodes.size());
         for (final Draw2dNode node : selectedNodes) {
             selection.add(node.getNode());
         }

--- a/src/main/java/net/ggtools/grand/ui/widgets/GraphTabItem.java
+++ b/src/main/java/net/ggtools/grand/ui/widgets/GraphTabItem.java
@@ -175,7 +175,7 @@ public class GraphTabItem extends CTabItem
                     targetIndex = 0;
                 }
 
-                result = (sourceIndex < targetIndex) ? -1 : ((sourceIndex == targetIndex) ? 0 : 1);
+                result = Integer.compare(sourceIndex, targetIndex);
             }
 
             return result;

--- a/src/main/java/net/ggtools/grand/ui/widgets/GraphWindow.java
+++ b/src/main/java/net/ggtools/grand/ui/widgets/GraphWindow.java
@@ -145,10 +145,7 @@ public class GraphWindow extends ApplicationWindow
             controllerRemovedDispatcher = controllerEventManager
                     .createDispatcher(GraphControllerListener.class.getDeclaredMethod(
                             "controllerRemoved", GraphController.class));
-        } catch (final SecurityException e) {
-            LOG.fatal("Caught exception initializing GraphController", e);
-            throw new RuntimeException("Cannot instantiate GraphController", e);
-        } catch (final NoSuchMethodException e) {
+        } catch (final SecurityException | NoSuchMethodException e) {
             LOG.fatal("Caught exception initializing GraphController", e);
             throw new RuntimeException("Cannot instantiate GraphController", e);
         }

--- a/src/main/java/net/ggtools/grand/ui/widgets/GraphWindow.java
+++ b/src/main/java/net/ggtools/grand/ui/widgets/GraphWindow.java
@@ -47,10 +47,8 @@ import net.ggtools.grand.ui.menu.ViewMenu;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.jface.action.MenuManager;
 import org.eclipse.jface.dialogs.ProgressMonitorDialog;
-import org.eclipse.jface.operation.IRunnableWithProgress;
 import org.eclipse.jface.window.ApplicationWindow;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.CTabFolder;
@@ -62,8 +60,6 @@ import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Display;
-import org.eclipse.swt.widgets.Event;
-import org.eclipse.swt.widgets.Listener;
 import org.eclipse.swt.widgets.Menu;
 import org.eclipse.swt.widgets.MenuItem;
 import org.eclipse.swt.widgets.Shell;
@@ -157,18 +153,10 @@ public class GraphWindow extends ApplicationWindow
 
             for (MenuItem systemItem : systemMenu.getItems()) {
                 if (systemItem.getID() == SWT.ID_PREFERENCES) {
-                    systemItem.addListener(SWT.Selection, new Listener() {
-                        public void handleEvent(final Event event) {
-                            runPreferencesAction();
-                        }
-                    });
+                    systemItem.addListener(SWT.Selection, event -> runPreferencesAction());
                 }
                 if (systemItem.getID() == SWT.ID_ABOUT) {
-                    systemItem.addListener(SWT.Selection, new Listener() {
-                        public void handleEvent(final Event event) {
-                            runAboutAction();
-                        }
-                    });
+                    systemItem.addListener(SWT.Selection, event -> runAboutAction());
                 }
             }
         }
@@ -260,15 +248,11 @@ public class GraphWindow extends ApplicationWindow
         final GraphController controller = new GraphController(this);
         try {
             new ProgressMonitorDialog(getShell()).run(true, false,
-                    new IRunnableWithProgress() {
-                            public void run(final IProgressMonitor monitor)
-                                    throws InvocationTargetException,
-                                            InterruptedException {
-                    controller.setProgressMonitor(monitor);
-                    controller.openFile(buildFile, properties);
-                    if (targetName != null) {
-                        controller.focusOn(targetName);
-                    }
+                    monitor -> {
+                controller.setProgressMonitor(monitor);
+                controller.openFile(buildFile, properties);
+                if (targetName != null) {
+                    controller.focusOn(targetName);
                 }
             });
         } catch (final InvocationTargetException e) {

--- a/src/main/java/net/ggtools/grand/ui/widgets/SafeProgressMonitor.java
+++ b/src/main/java/net/ggtools/grand/ui/widgets/SafeProgressMonitor.java
@@ -79,12 +79,7 @@ public class SafeProgressMonitor implements IProgressMonitor {
      * @see org.eclipse.core.runtime.IProgressMonitor#done()
      */
     public final void done() {
-        display.asyncExec(new Runnable() {
-
-            public void run() {
-                monitor.done();
-            }
-        });
+        display.asyncExec(monitor::done);
     }
 
     /**

--- a/src/main/java/net/ggtools/grand/ui/widgets/SafeProgressMonitor.java
+++ b/src/main/java/net/ggtools/grand/ui/widgets/SafeProgressMonitor.java
@@ -66,12 +66,7 @@ public class SafeProgressMonitor implements IProgressMonitor {
      * @see org.eclipse.core.runtime.IProgressMonitor#beginTask(java.lang.String, int)
      */
     public final void beginTask(final String name, final int totalWork) {
-        display.asyncExec(new Runnable() {
-
-            public void run() {
-                monitor.beginTask(name, totalWork);
-            }
-        });
+        display.asyncExec(() -> monitor.beginTask(name, totalWork));
     }
 
     /**
@@ -88,12 +83,7 @@ public class SafeProgressMonitor implements IProgressMonitor {
      * @see org.eclipse.core.runtime.IProgressMonitor#internalWorked(double)
      */
     public final void internalWorked(final double work) {
-        display.asyncExec(new Runnable() {
-
-            public void run() {
-                monitor.internalWorked(work);
-            }
-        });
+        display.asyncExec(() -> monitor.internalWorked(work));
     }
 
     /**
@@ -113,12 +103,7 @@ public class SafeProgressMonitor implements IProgressMonitor {
      * @see org.eclipse.core.runtime.IProgressMonitor#setCanceled(boolean)
      */
     public final void setCanceled(final boolean value) {
-        display.asyncExec(new Runnable() {
-
-            public void run() {
-                monitor.setCanceled(value);
-            }
-        });
+        display.asyncExec(() -> monitor.setCanceled(value));
     }
 
     /**
@@ -127,12 +112,7 @@ public class SafeProgressMonitor implements IProgressMonitor {
      * @see org.eclipse.core.runtime.IProgressMonitor#setTaskName(java.lang.String)
      */
     public final void setTaskName(final String name) {
-        display.asyncExec(new Runnable() {
-
-            public void run() {
-                monitor.setTaskName(name);
-            }
-        });
+        display.asyncExec(() -> monitor.setTaskName(name));
     }
 
     /**
@@ -141,12 +121,7 @@ public class SafeProgressMonitor implements IProgressMonitor {
      * @see org.eclipse.core.runtime.IProgressMonitor#subTask(java.lang.String)
      */
     public final void subTask(final String name) {
-        display.asyncExec(new Runnable() {
-
-            public void run() {
-                monitor.subTask(name);
-            }
-        });
+        display.asyncExec(() -> monitor.subTask(name));
     }
 
     /**
@@ -155,12 +130,7 @@ public class SafeProgressMonitor implements IProgressMonitor {
      * @see org.eclipse.core.runtime.IProgressMonitor#worked(int)
      */
     public final void worked(final int work) {
-        display.asyncExec(new Runnable() {
-
-            public void run() {
-                monitor.worked(work);
-            }
-        });
+        display.asyncExec(() -> monitor.worked(work));
     }
 
 }

--- a/src/main/java/net/ggtools/grand/ui/widgets/property/PropertyEditor.java
+++ b/src/main/java/net/ggtools/grand/ui/widgets/property/PropertyEditor.java
@@ -436,7 +436,7 @@ public class PropertyEditor {
     public PropertyEditor(final Composite parent, final int style) {
         synchronized (this) {
             if (columnNamesToNumMap == null) {
-                columnNamesToNumMap = new HashMap<String, Integer>();
+                columnNamesToNumMap = new HashMap<>();
                 columnNamesToNumMap.put(STATUS_COLUMN, STATUS_COLUMN_NUM);
                 columnNamesToNumMap.put(NAME_COLUMN, NAME_COLUMN_NUM);
                 columnNamesToNumMap.put(VALUE_COLUMN, VALUE_COLUMN_NUM);

--- a/src/main/java/net/ggtools/grand/ui/widgets/property/PropertyEditor.java
+++ b/src/main/java/net/ggtools/grand/ui/widgets/property/PropertyEditor.java
@@ -156,11 +156,7 @@ public class PropertyEditor {
          * @see net.ggtools.grand.ui.widgets.property.PropertyChangedListener#allPropertiesChanged(Object)
          */
         public void allPropertiesChanged(final Object fillerParameter) {
-            tableViewer.getTable().getDisplay().asyncExec(new Runnable() {
-                public void run() {
-                    tableViewer.refresh();
-                }
-            });
+            tableViewer.getTable().getDisplay().asyncExec(() -> tableViewer.refresh());
         }
 
         /**
@@ -169,11 +165,7 @@ public class PropertyEditor {
          * @see net.ggtools.grand.ui.widgets.property.PropertyChangedListener#clearedProperties(Object)
          */
         public void clearedProperties(final Object fillerParameter) {
-            tableViewer.getTable().getDisplay().asyncExec(new Runnable() {
-                public void run() {
-                    tableViewer.refresh();
-                }
-            });
+            tableViewer.getTable().getDisplay().asyncExec(() -> tableViewer.refresh());
         }
 
         /**
@@ -227,11 +219,7 @@ public class PropertyEditor {
          * @see net.ggtools.grand.ui.widgets.property.PropertyChangedListener#propertyAdded(PropertyPair)
          */
         public void propertyAdded(final PropertyPair propertyPair) {
-            tableViewer.getTable().getDisplay().asyncExec(new Runnable() {
-                public void run() {
-                    tableViewer.refresh();
-                }
-            });
+            tableViewer.getTable().getDisplay().asyncExec(() -> tableViewer.refresh());
         }
 
         /**
@@ -240,11 +228,7 @@ public class PropertyEditor {
          * @see net.ggtools.grand.ui.widgets.property.PropertyChangedListener#propertyChanged(PropertyPair)
          */
         public void propertyChanged(final PropertyPair propertyPair) {
-            tableViewer.getTable().getDisplay().asyncExec(new Runnable() {
-                public void run() {
-                    tableViewer.update(propertyPair, null);
-                }
-            });
+            tableViewer.getTable().getDisplay().asyncExec(() -> tableViewer.update(propertyPair, null));
         }
 
         /**
@@ -253,11 +237,7 @@ public class PropertyEditor {
          * @see net.ggtools.grand.ui.widgets.property.PropertyChangedListener#propertyRemoved(PropertyPair)
          */
         public void propertyRemoved(final PropertyPair propertyPair) {
-            tableViewer.getTable().getDisplay().asyncExec(new Runnable() {
-                public void run() {
-                    tableViewer.refresh();
-                }
-            });
+            tableViewer.getTable().getDisplay().asyncExec(() -> tableViewer.refresh());
         }
     }
 

--- a/src/main/java/net/ggtools/grand/ui/widgets/property/PropertyList.java
+++ b/src/main/java/net/ggtools/grand/ui/widgets/property/PropertyList.java
@@ -103,10 +103,7 @@ class PropertyList {
             allPropertiesChangedDispatcher = eventManager
                     .createDispatcher(PropertyChangedListener.class.getDeclaredMethod(
                             "allPropertiesChanged", Object.class));
-        } catch (final SecurityException e) {
-            LOG.fatal("Caught exception initializing PropertyList", e);
-            throw new RuntimeException("Cannot instantiate PropertyList", e);
-        } catch (final NoSuchMethodException e) {
+        } catch (final SecurityException | NoSuchMethodException e) {
             LOG.fatal("Caught exception initializing PropertyList", e);
             throw new RuntimeException("Cannot instantiate PropertyList", e);
         }

--- a/src/main/java/net/ggtools/grand/ui/widgets/property/PropertyList.java
+++ b/src/main/java/net/ggtools/grand/ui/widgets/property/PropertyList.java
@@ -83,7 +83,7 @@ class PropertyList {
     /**
      * Field pairList.
      */
-    private final Set<PropertyPair> pairList = new HashSet<PropertyPair>();
+    private final Set<PropertyPair> pairList = new HashSet<>();
 
     /**
      * Constructor for PropertyList.

--- a/src/main/java/net/ggtools/grand/ui/widgets/property/PropertyList.java
+++ b/src/main/java/net/ggtools/grand/ui/widgets/property/PropertyList.java
@@ -177,7 +177,7 @@ class PropertyList {
      * @return PropertyPair[]
      */
     public PropertyPair[] toArray() {
-        return pairList.toArray(new PropertyPair[pairList.size()]);
+        return pairList.toArray(new PropertyPair[0]);
     }
 
     /**

--- a/src/main/scripts/grand-ui.bat
+++ b/src/main/scripts/grand-ui.bat
@@ -1,13 +1,12 @@
 @set BASEDIR=%~dp0
 
-@set ARCH=x86_64
 @java -version 2>&1 | findstr 64 >nul
-@if ERRORLEVEL 1 set ARCH=x86
+@if ERRORLEVEL 1 (echo "SWT 4.10+ requires 64-bit Java" & exit /b 1)
 
 @for /f tokens^=2^ delims^=.-+_^" %%j in ('java -fullversion 2^>^&1') do set "java.major=%%j"
 if %java.major%==1 (
-    start javaw -Djava.ext.dirs=%BASEDIR%lib;%BASEDIR%lib\win32\%ARCH% -jar %BASEDIR%lib\grand-ui.jar
+    start javaw -Djava.ext.dirs=%BASEDIR%lib;%BASEDIR%lib\win32 -jar %BASEDIR%lib\grand-ui.jar
 ) else (
-    start javaw -p %BASEDIR%lib;%BASEDIR%lib\win32\%ARCH% -m grand.ui
+    start javaw -p %BASEDIR%lib;%BASEDIR%lib\win32 -m grand.ui
 )
 @exit

--- a/src/main/scripts/grand-ui.sh
+++ b/src/main/scripts/grand-ui.sh
@@ -16,13 +16,13 @@ done
 
 BASEDIR=`dirname "$PRG"`
 
-ARCH=x86_64
 if [ `java -version 2>&1 | grep -c 64` -eq 0 ]; then
-    ARCH=x86
+    echo "SWT 4.10+ requires 64-bit Java"
+    exit 1
 fi
 
 if [ `java -version 2>&1 | sed -n 's/.* version "\([^.]*\)\..*".*/\1/p'` -eq 1 ]; then
-    java -Djava.ext.dirs=$BASEDIR/lib:$BASEDIR/lib/gtk/$ARCH -jar $BASEDIR/lib/grand-ui.jar
+    java -Djava.ext.dirs=$BASEDIR/lib:$BASEDIR/lib/gtk -jar $BASEDIR/lib/grand-ui.jar
 else
-    java -p $BASEDIR/lib:$BASEDIR/lib/gtk/$ARCH -m grand.ui
+    java -p $BASEDIR/lib:$BASEDIR/lib/gtk -m grand.ui
 fi


### PR DESCRIPTION
NB! Eclipse 4.10 drops support for 32-bit platforms.
Also, fix ImageSaver so that it follows SWT specification (see #18) and improve ExportGraphAction to add image file extension based on selected filter.